### PR TITLE
feat: Add /planapp plan-first app building

### DIFF
--- a/commands/planapp.py
+++ b/commands/planapp.py
@@ -1,0 +1,195 @@
+"""
+commands/planapp.py — Generate a structured app plan before building.
+
+/planapp <description>
+  → Claude generates screens, navigation, data model, tech decisions
+  → User reviews and approves → /buildapp executes with plan context
+"""
+
+import json
+import re
+from typing import Optional
+
+from claude_runner import ClaudeRunner
+
+
+PLAN_PROMPT = """You are an expert mobile app architect. Given the app description below,
+generate a structured plan for a Kotlin Multiplatform (Compose Multiplatform) app.
+
+App description: {description}
+
+Output a JSON object with EXACTLY this structure (no markdown fences, just raw JSON):
+{{
+  "app_name": "SuggestedAppName",
+  "summary": "One-sentence summary of what the app does",
+  "screens": [
+    {{
+      "name": "Screen Name",
+      "description": "What this screen shows and does",
+      "key_components": ["Component1", "Component2"]
+    }}
+  ],
+  "navigation": {{
+    "type": "bottom_tabs | drawer | stack",
+    "flow": "Brief description of how users move between screens"
+  }},
+  "data_model": [
+    {{
+      "entity": "EntityName",
+      "fields": ["field1: Type", "field2: Type"],
+      "description": "What this entity represents"
+    }}
+  ],
+  "features": [
+    "Feature 1 description",
+    "Feature 2 description"
+  ],
+  "tech_decisions": [
+    "Decision 1 (e.g. 'Ktor + Supabase for backend')",
+    "Decision 2"
+  ]
+}}
+
+Rules:
+- Keep it practical and buildable in one session
+- 3-6 screens max
+- Focus on core functionality, not nice-to-haves
+- Data model should map cleanly to Supabase tables
+- Output ONLY the JSON object, no other text
+"""
+
+
+def parse_plan_json(raw: str) -> Optional[dict]:
+    """Extract and parse the plan JSON from Claude's response."""
+    # Try direct parse first
+    try:
+        return json.loads(raw.strip())
+    except json.JSONDecodeError:
+        pass
+
+    # Try extracting from markdown code fences
+    m = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", raw, re.DOTALL)
+    if m:
+        try:
+            return json.loads(m.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Try finding first { to last }
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        try:
+            return json.loads(raw[start:end + 1])
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def format_plan_embed(plan: dict) -> dict:
+    """Format a plan dict into fields suitable for a Discord embed."""
+    fields = []
+
+    # Screens
+    screens = plan.get("screens", [])
+    if screens:
+        screen_lines = []
+        for i, s in enumerate(screens, 1):
+            components = ", ".join(s.get("key_components", []))
+            line = f"**{i}. {s['name']}** — {s['description']}"
+            if components:
+                line += f"\n   _{components}_"
+            screen_lines.append(line)
+        fields.append(("📱 Screens", "\n".join(screen_lines)))
+
+    # Navigation
+    nav = plan.get("navigation", {})
+    if nav:
+        nav_text = f"**{nav.get('type', 'stack').replace('_', ' ').title()}**\n{nav.get('flow', '')}"
+        fields.append(("🧭 Navigation", nav_text))
+
+    # Data Model
+    entities = plan.get("data_model", [])
+    if entities:
+        entity_lines = []
+        for e in entities:
+            field_str = ", ".join(e.get("fields", []))
+            entity_lines.append(f"**{e['entity']}** — {e.get('description', '')}\n`{field_str}`")
+        fields.append(("🗄️ Data Model", "\n".join(entity_lines)))
+
+    # Features
+    features = plan.get("features", [])
+    if features:
+        feature_text = "\n".join(f"• {f}" for f in features)
+        fields.append(("✨ Features", feature_text))
+
+    # Tech Decisions
+    tech = plan.get("tech_decisions", [])
+    if tech:
+        tech_text = "\n".join(f"• {t}" for t in tech)
+        fields.append(("🔧 Tech Stack", tech_text))
+
+    return {
+        "title": f"App Plan: {plan.get('app_name', 'Untitled')}",
+        "summary": plan.get("summary", ""),
+        "fields": fields,
+    }
+
+
+async def generate_plan(
+    description: str,
+    claude: ClaudeRunner,
+    workspace_key: str = "_planapp",
+    workspace_path: str = "/tmp",
+) -> Optional[dict]:
+    """Generate an app plan using Claude. Returns parsed plan dict or None."""
+    prompt = PLAN_PROMPT.format(description=description)
+    result = await claude.run(prompt, workspace_key, workspace_path)
+
+    if result.exit_code != 0:
+        return None
+
+    plan = parse_plan_json(result.stdout)
+    if plan:
+        # Preserve the original description
+        plan["_original_description"] = description
+    return plan
+
+
+def plan_to_buildapp_prompt(plan: dict) -> str:
+    """Convert a plan dict into a rich description for /buildapp."""
+    parts = [plan.get("_original_description", "")]
+
+    screens = plan.get("screens", [])
+    if screens:
+        parts.append("\n\nScreens:")
+        for s in screens:
+            components = ", ".join(s.get("key_components", []))
+            parts.append(f"- {s['name']}: {s['description']}" +
+                        (f" (components: {components})" if components else ""))
+
+    nav = plan.get("navigation", {})
+    if nav:
+        parts.append(f"\nNavigation: {nav.get('type', 'stack')} — {nav.get('flow', '')}")
+
+    entities = plan.get("data_model", [])
+    if entities:
+        parts.append("\nData model:")
+        for e in entities:
+            fields = ", ".join(e.get("fields", []))
+            parts.append(f"- {e['entity']}: {fields}")
+
+    features = plan.get("features", [])
+    if features:
+        parts.append("\nKey features:")
+        for f in features:
+            parts.append(f"- {f}")
+
+    tech = plan.get("tech_decisions", [])
+    if tech:
+        parts.append("\nTech decisions:")
+        for t in tech:
+            parts.append(f"- {t}")
+
+    return "\n".join(parts)

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -12,6 +12,7 @@ This __init__ merges them into a single COMMAND_HANDLERS dict.
 from handlers import (
     workspace_commands,
     build_commands,
+    plan_commands,
     publish_commands,
     save_git_commands,
     admin_commands,
@@ -22,6 +23,7 @@ from handlers import (
 COMMAND_HANDLERS = {
     **workspace_commands.HANDLERS,
     **build_commands.HANDLERS,
+    **plan_commands.HANDLERS,
     **publish_commands.HANDLERS,
     **save_git_commands.HANDLERS,
     **admin_commands.HANDLERS,

--- a/handlers/plan_commands.py
+++ b/handlers/plan_commands.py
@@ -1,0 +1,33 @@
+"""
+handlers/plan_commands.py — /planapp command handler.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import config
+from views.planapp_views import PlanAppView
+
+if TYPE_CHECKING:
+    from bot_context import BotContext
+    from parser import Command
+
+
+async def handle_planapp(ctx: BotContext, cmd: Command, channel, user_id: int, is_admin: bool) -> None:
+    if not config.AGENT_MODE:
+        await ctx.send(channel, "🔒 Agent mode OFF.")
+    else:
+        prefill = cmd.raw_cmd or ""
+        view = PlanAppView(ctx, channel, user_id, is_admin, prefill)
+        await channel.send(
+            "**Plan before you build!** Describe your app idea and I'll create a structured plan "
+            "with screens, navigation, data model, and features — before writing any code.\n\n"
+            "Review the plan, then hit **Build** when you're happy.",
+            view=view,
+        )
+
+
+HANDLERS = {
+    "planapp": handle_planapp,
+}

--- a/helpers/ui_helpers.py
+++ b/helpers/ui_helpers.py
@@ -14,6 +14,7 @@ def help_text(is_admin: bool = True):
     lines = [
         "**discord-claude-bridge** — build apps from chat" + agent + "\n",
         "**Build & Preview:**",
+        "`/planapp` — plan your app first (screens, data model, features)",
         "`/build app <description>` — idea \u2192 running app",
         "`/demo` — build + preview your app",
         "`/testflight` — when happy, publish to TestFlight (iOS). Ping `jared.e.tan@gmail.com` for setup.",

--- a/parser.py
+++ b/parser.py
@@ -66,6 +66,9 @@ def parse(text: str) -> ParseResult:
             case "/buildapp" | "/build-app":
                 return Command(name="buildapp", raw_cmd=rest or None)
 
+            case "/planapp" | "/plan-app" | "/plan":
+                return Command(name="planapp", raw_cmd=rest or None)
+
             case "/build":
                 # "/build app <desc>" is an alias for "/buildapp <desc>"
                 if rest and rest.lower().startswith("app"):

--- a/views/planapp_views.py
+++ b/views/planapp_views.py
@@ -1,0 +1,186 @@
+"""
+views/planapp_views.py — Plan-app modal, embed, and approve/build buttons.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import discord
+
+from commands import planapp
+from commands.buildapp import infer_app_name
+
+if TYPE_CHECKING:
+    from bot_context import BotContext
+
+
+# ── Persistent plan storage ──────────────────────────────────────────────────
+
+_PLANS_FILE = Path(__file__).resolve().parent.parent / "app_plans.json"
+
+
+def _load_plans() -> dict:
+    if _PLANS_FILE.exists():
+        try:
+            with open(_PLANS_FILE) as f:
+                return json.load(f)
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return {}
+
+
+def _save_plan(user_id: int, plan: dict):
+    plans = _load_plans()
+    plans[str(user_id)] = plan
+    with open(_PLANS_FILE, "w") as f:
+        json.dump(plans, f, indent=2)
+
+
+def get_plan(user_id: int) -> dict | None:
+    plans = _load_plans()
+    return plans.get(str(user_id))
+
+
+# ── Discord embed from plan ──────────────────────────────────────────────────
+
+def plan_embed(plan: dict) -> discord.Embed:
+    """Build a rich Discord embed from a plan dict."""
+    fmt = planapp.format_plan_embed(plan)
+    embed = discord.Embed(
+        title=fmt["title"],
+        description=fmt["summary"],
+        color=0x5865F2,  # Discord blurple
+    )
+    for name, value in fmt["fields"]:
+        # Discord embed field value max is 1024 chars
+        embed.add_field(name=name, value=value[:1024], inline=False)
+    embed.set_footer(text="Review this plan, then tap Build to start — or Edit to refine it.")
+    return embed
+
+
+# ── Modal: enter app description ─────────────────────────────────────────────
+
+class _PlanAppModal(discord.ui.Modal, title="Plan your app"):
+    description = discord.ui.TextInput(
+        label="Describe your app idea",
+        style=discord.TextStyle.long,
+        placeholder="e.g. a meal planner that suggests recipes based on what's in your fridge, with a grocery list and calorie tracker",
+        required=True,
+        max_length=4000,
+    )
+
+    def __init__(self, ctx: BotContext, channel, user_id: int, is_admin: bool, prefill: str = ""):
+        super().__init__()
+        self.ctx = ctx
+        self.channel = channel
+        self.user_id = user_id
+        self.is_admin = is_admin
+        if prefill:
+            self.description.default = prefill[:4000]
+
+    async def on_submit(self, interaction: discord.Interaction):
+        desc = self.description.value.strip()
+        await interaction.response.send_message(
+            "🧠 Planning your app — this takes about 30 seconds...", ephemeral=True,
+        )
+
+        plan = await planapp.generate_plan(
+            desc, self.ctx.claude,
+        )
+
+        if not plan:
+            await self.ctx.send(
+                self.channel,
+                "❌ Could not generate a plan. Try again with a more detailed description.",
+            )
+            return
+
+        # Store plan for this user
+        _save_plan(self.user_id, plan)
+
+        # Send the plan embed with action buttons
+        embed = plan_embed(plan)
+        view = _PlanActionView(self.ctx, self.channel, self.user_id, self.is_admin, plan)
+        await self.channel.send(embed=embed, view=view)
+
+
+# ── View: button to open the modal ──────────────────────────────────────────
+
+class PlanAppView(discord.ui.View):
+    def __init__(self, ctx: BotContext, channel, user_id: int, is_admin: bool, prefill: str = ""):
+        super().__init__(timeout=300)
+        self.ctx = ctx
+        self.channel = channel
+        self.user_id = user_id
+        self.is_admin = is_admin
+        self.prefill = prefill
+
+    @discord.ui.button(label="Describe your app", style=discord.ButtonStyle.success, emoji="🧠")
+    async def describe_app(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.user_id:
+            return await interaction.response.send_message("Not your command.", ephemeral=True)
+        await interaction.response.send_modal(
+            _PlanAppModal(self.ctx, self.channel, self.user_id, self.is_admin, self.prefill)
+        )
+
+
+# ── View: approve / edit / rebuild plan ──────────────────────────────────────
+
+class _PlanActionView(discord.ui.View):
+    def __init__(self, ctx: BotContext, channel, user_id: int, is_admin: bool, plan: dict):
+        super().__init__(timeout=600)
+        self.ctx = ctx
+        self.channel = channel
+        self.user_id = user_id
+        self.is_admin = is_admin
+        self.plan = plan
+
+    @discord.ui.button(label="Build this app", style=discord.ButtonStyle.success, emoji="🚀")
+    async def build_app(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.user_id:
+            return await interaction.response.send_message("Not your command.", ephemeral=True)
+
+        # Disable buttons
+        for item in self.children:
+            item.disabled = True
+        await interaction.message.edit(view=self)
+
+        app_name = self.plan.get("app_name", infer_app_name(
+            self.plan.get("_original_description", "MyApp")
+        ))
+        enriched_desc = planapp.plan_to_buildapp_prompt(self.plan)
+
+        await interaction.response.send_message(
+            f"🚀 Building **{app_name}** from plan...", ephemeral=True,
+        )
+
+        # Import and trigger buildapp
+        from commands.buildapp import handle_buildapp as ba_handle
+
+        async def ba_status(msg, fpath=None):
+            await self.ctx.send(self.channel, msg, file_path=fpath)
+
+        slug = await ba_handle(
+            enriched_desc,
+            self.ctx.registry,
+            self.ctx.claude,
+            ba_status,
+            is_admin=self.is_admin,
+            owner_id=self.user_id,
+            app_name=app_name,
+        )
+        if slug:
+            self.ctx.registry.set_default(self.user_id, slug)
+            await self.ctx.send(self.channel, f"📂 Switched to **{slug}**")
+
+    @discord.ui.button(label="Re-plan", style=discord.ButtonStyle.secondary, emoji="🔄")
+    async def replan(self, interaction: discord.Interaction, button: discord.ui.Button):
+        if interaction.user.id != self.user_id:
+            return await interaction.response.send_message("Not your command.", ephemeral=True)
+        original_desc = self.plan.get("_original_description", "")
+        await interaction.response.send_modal(
+            _PlanAppModal(self.ctx, self.channel, self.user_id, self.is_admin, original_desc)
+        )


### PR DESCRIPTION
## Research
The strongest cross-competitor trend this week is **plan-first workflows**: Replit Agent 4's Plan mode, Lovable's plan-before-execute Chat mode, and Cursor's preview-before-act Automations all emphasize showing users what will happen before executing. Users waste credits/time when AI builds the wrong thing — a structured preview step dramatically improves success rates.

## Changes
- **`commands/planapp.py`** — Planning prompt, JSON parsing, plan formatting, and plan-to-buildapp enrichment
- **`views/planapp_views.py`** — Discord modal for app description, rich embed for plan display, Build/Re-plan action buttons, persistent plan storage (`app_plans.json`)
- **`handlers/plan_commands.py`** — `/planapp` command handler
- **`parser.py`** — Added `/planapp`, `/plan-app`, `/plan` command parsing
- **`handlers/__init__.py`** — Registered plan_commands handler
- **`helpers/ui_helpers.py`** — Added `/planapp` to help text

### Flow
1. User runs `/planapp` → modal opens for app description
2. Claude generates structured plan (screens, navigation, data model, features, tech stack)
3. Plan displayed as rich Discord embed with action buttons
4. **Build** → converts plan to enriched description and runs `/buildapp` with full context
5. **Re-plan** → re-opens modal with original description to iterate

## Competitors
- **Replit Agent 4** — Plan mode + Design Canvas: map out projects in plain language before coding
- **Lovable** — Chat mode shows execution plan before building, reducing wasted credits (crossed $300M+ ARR)
- **Cursor** — Automations with structured preview before execution
- **Base44** — Direct App Store/Play Store deployment (competitive threat to our publishing flow)

---
*Auto-generated by nightly competitive research script*