### PR TITLE
P1: Parallel builds — web link first, native in background

### DIFF
--- a/handlers/build_commands.py
+++ b/handlers/build_commands.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import config
-from helpers.demo_runner import run_demo
+from helpers.demo_runner import run_demo, run_demo_all
 from views.buildapp_views import _BuildAppView
 from views.deploy_embeds import _ios_deploy_info_embed
 
@@ -83,6 +83,14 @@ async def handle_demo(ctx: BotContext, cmd: Command, channel, user_id: int, is_a
                     "🔒 `/demo android` is admin-only. Use `/demo web` to test in your browser, "
                     "or `/playstore` to publish to Google Play Store for testing.",
                 )
+        elif cmd.platform == "all":
+            if not is_admin:
+                await ctx.send(
+                    channel,
+                    "🔒 `/demo all` is admin-only (requires iOS + Android access).",
+                )
+            else:
+                await run_demo_all(ctx, channel, ws_key, ws_path)
         elif cmd.platform:
             # /demo android, /demo ios, /demo web -> run directly
             prev = ctx.registry.get_platform(user_id)

--- a/helpers/demo_runner.py
+++ b/helpers/demo_runner.py
@@ -22,16 +22,48 @@ from platforms import (
 from helpers.web_screenshot import take_web_screenshot
 
 
+async def run_demo_all(ctx, channel, ws_key: str, ws_path: str,
+                       budget: BudgetTracker = None):
+    """Run web first (deliver link immediately), then iOS + Android in parallel."""
+    if budget is None:
+        budget = BudgetTracker(
+            max_cost_usd=config.MAX_FIX_BUDGET_USD,
+            max_invocations=config.MAX_TOTAL_INVOCATIONS,
+        )
+
+    await ctx.send(channel, f"📱 Demoing **{ws_key}** [all platforms]...")
+    await ctx.send(channel, STILL_LISTENING)
+
+    # --- Phase 1: Web builds first, deliver link immediately ---
+    await run_demo(ctx, channel, ws_key, ws_path, "web", budget=budget)
+
+    # --- Phase 2: iOS + Android build in parallel ---
+    await ctx.send(channel, "🔨 Starting native builds (iOS + Android) in parallel...")
+
+    async def _run_native(platform: str):
+        try:
+            await run_demo(ctx, channel, ws_key, ws_path, platform,
+                           budget=budget, announce=False)
+        except Exception as exc:
+            await ctx.send(channel, f"❌ {platform} demo failed: {exc}")
+
+    await asyncio.gather(
+        _run_native("ios"),
+        _run_native("android"),
+    )
+
+
 async def run_demo(ctx, channel, ws_key: str, ws_path: str, platform: str,
-                   budget: BudgetTracker = None):
+                   budget: BudgetTracker = None, announce: bool = True):
     """Run a demo for a single platform."""
     if budget is None:
         budget = BudgetTracker(
             max_cost_usd=config.MAX_FIX_BUDGET_USD,
             max_invocations=config.MAX_TOTAL_INVOCATIONS,
         )
-    await ctx.send(channel, f"📱 Demoing **{ws_key}** [{platform}]...")
-    await ctx.send(channel, STILL_LISTENING)
+    if announce:
+        await ctx.send(channel, f"📱 Demoing **{ws_key}** [{platform}]...")
+        await ctx.send(channel, STILL_LISTENING)
 
     if platform == "ios":
         progress = ProgressMessage(ctx, channel, title=f"iOS Demo — {ws_key}")

--- a/parser.py
+++ b/parser.py
@@ -31,7 +31,7 @@ class FallbackPrompt:
 
 ParseResult = WorkspacePrompt | Command | FallbackPrompt
 
-PLATFORMS = {"android", "ios", "web"}
+PLATFORMS = {"android", "ios", "web", "all"}
 
 
 def _parse_platform(text: str) -> tuple[Optional[str], str]:


### PR DESCRIPTION
Closes #6

- Web builds first, delivers live link immediately
- iOS + Android then build in parallel via asyncio.gather
- Each platform gets its own ProgressMessage
- Web link sent as standalone message so it doesn't scroll away