### PR TITLE
P1: Screenshot-driven iteration — visual bug fixing

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -140,9 +140,9 @@ async def on_message(message: discord.Message):
     if not text and not has_images:
         return
 
-    # Image-only message: treat as a prompt describing the image
+    # Image-only message: treat as a visual bug report
     if not text and has_images:
-        text = "Look at the attached image(s) and describe what you see. If it looks like a bug or UI issue, suggest how to fix it."
+        text = "Fix the visual bug shown in the attached screenshot(s). Compare against the current app state and make the necessary code changes."
 
     parsed = msg_parser.parse(text)
     channel = message.channel

--- a/handlers/prompt_handler.py
+++ b/handlers/prompt_handler.py
@@ -24,6 +24,11 @@ from views.interview_views import CancelRequestView
 from helpers.ui_helpers import send_workspace_footer
 from helpers.pro_tips import pro_tip_embed, ProTipsDismissView, TIPS
 from helpers.web_screenshot import take_web_screenshot
+from helpers.screenshot_compare import (
+    take_app_screenshot,
+    build_visual_diff_prompt,
+    _guess_route_from_text,
+)
 
 if TYPE_CHECKING:
     from bot_context import BotContext
@@ -97,15 +102,16 @@ async def handle_prompt(
             "Google Maps will be supported in a future update."
         )
 
-    # Download image attachments and augment prompt
+    # Download image attachments and augment prompt with visual comparison
     image_paths = await _save_attachments(attachments, ws_path)
     if image_paths:
-        paths_str = "\n".join(f"  - {p}" for p in image_paths)
-        prompt = (
-            f"The user attached {len(image_paths)} image(s). "
-            f"Read these files to see what they shared:\n{paths_str}\n\n{prompt}"
-        )
-        await ctx.send(channel, f"📎 {len(image_paths)} image(s) attached — Claude will review them.")
+        await ctx.send(channel, f"📎 {len(image_paths)} image(s) attached — capturing current app state…")
+        route = _guess_route_from_text(prompt)
+        bot_screenshot = await take_app_screenshot(path=route)
+        if bot_screenshot:
+            await ctx.send(channel, f"📸 Captured current app at `{route}` for comparison.")
+        diff_prompt = build_visual_diff_prompt(image_paths, bot_screenshot)
+        prompt = f"{diff_prompt}\n\nUser message: {prompt}"
 
     cancel_view = CancelRequestView(ctx, user_id, ws_key)
     cancel_msg = await channel.send(

--- a/helpers/screenshot_compare.py
+++ b/helpers/screenshot_compare.py
@@ -1,0 +1,124 @@
+"""
+helpers/screenshot_compare.py — Screenshot comparison for visual bug fixing.
+
+Takes screenshots of the running web app and builds prompts that help Claude
+understand visual differences between the user's screenshot and the current app state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import tempfile
+from pathlib import Path
+
+import config
+
+
+async def take_app_screenshot(
+    path: str = "/",
+    wait_ms: int = 3000,
+) -> str | None:
+    """Take a screenshot of the running web app at the given route.
+
+    *path* is appended to ``http://localhost:{WEB_SERVE_PORT}`` so callers can
+    target specific screens (e.g. ``/settings``, ``/login``).
+
+    Returns the file path to the PNG screenshot, or ``None`` on failure.
+    """
+    try:
+        from playwright.async_api import async_playwright
+    except ImportError:
+        return None
+
+    # Normalise path so it always starts with /
+    if not path.startswith("/"):
+        path = f"/{path}"
+
+    url = f"http://localhost:{config.WEB_SERVE_PORT}{path}"
+    screenshot_path = Path(tempfile.gettempdir()) / "app_screenshot.png"
+
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            page = await browser.new_page(viewport={"width": 390, "height": 844})
+            await page.goto(url, wait_until="networkidle", timeout=30_000)
+            # Extra wait for WASM / Compose for Web to finish rendering
+            await asyncio.sleep(wait_ms / 1000)
+            await page.screenshot(path=str(screenshot_path), full_page=False)
+            await browser.close()
+        return str(screenshot_path) if screenshot_path.exists() else None
+    except Exception:
+        return None
+
+
+def _guess_route_from_text(text: str) -> str:
+    """Try to extract a route/screen name from the user's message.
+
+    Looks for patterns like "on the /settings page", "the login screen",
+    "/profile route", etc.  Returns ``"/"`` when nothing is detected.
+    """
+    # Explicit route mention  e.g. "/settings", "/about"
+    m = re.search(r"(?:on|at|the|navigate to|go to)?\s*(/[a-zA-Z0-9_/-]+)", text)
+    if m:
+        return m.group(1)
+
+    # Named screen reference  e.g. "settings screen", "login page"
+    m = re.search(
+        r"\b([\w-]+)\s+(?:screen|page|route|view|tab)\b",
+        text,
+        re.IGNORECASE,
+    )
+    if m:
+        name = m.group(1).lower()
+        # Ignore filler words that aren't real screen names
+        if name not in {"the", "this", "that", "a", "an", "main", "first", "same", "home"}:
+            return f"/{name}"
+
+    return "/"
+
+
+def build_visual_diff_prompt(
+    user_image_paths: list[str],
+    bot_screenshot_path: str | None,
+) -> str:
+    """Return a prompt section that asks Claude to compare screenshots.
+
+    *user_image_paths*  — images the user uploaded (bugs / desired state).
+    *bot_screenshot_path* — screenshot of the app's current state (may be None).
+    """
+    lines: list[str] = []
+
+    lines.append(
+        "## Visual Bug Report — Screenshot Comparison\n"
+    )
+
+    # User images
+    lines.append(
+        f"The user attached {len(user_image_paths)} screenshot(s) showing "
+        "a bug or the desired UI. Read these files:\n"
+    )
+    for p in user_image_paths:
+        lines.append(f"  - {p}")
+
+    # Bot screenshot
+    if bot_screenshot_path:
+        lines.append(
+            f"\nThe app's CURRENT state has been captured automatically:\n"
+            f"  - {bot_screenshot_path}\n"
+        )
+        lines.append(
+            "Compare the user's screenshot(s) against the current app screenshot.\n"
+            "Identify every visual difference — layout, colours, spacing, missing "
+            "elements, broken styling, wrong text, etc.\n"
+            "Then fix the code so the app matches what the user expects."
+        )
+    else:
+        lines.append(
+            "\n(Could not capture a live screenshot of the app — compare against "
+            "your understanding of the codebase instead.)\n"
+            "Identify the visual issues shown in the user's screenshot(s) and fix "
+            "the code to resolve them."
+        )
+
+    return "\n".join(lines)


### PR DESCRIPTION
Closes #7

- New helpers/screenshot_compare.py module
- Captures app screenshots at specific routes via Playwright
- Generates comparison prompts for Claude when user sends a bug screenshot
- Integrated into prompt handler for @mention messages with images