### PR TITLE
P2: Auto-fix PR on smoke test failure

### DIFF
--- a/commands/smoketest.py
+++ b/commands/smoketest.py
@@ -42,7 +42,24 @@ async def handle_smoketest(
         owner_id=user_id,
     )
 
-    await ctx.send(channel, result.summary())
+    # Attempt auto-fix if smoke test failed
+    pr_url = None
+    if not result.success and config.AUTO_FIX_ON_FAILURE:
+        await ctx.send(channel, "🔧 Smoke test failed — attempting auto-fix...")
+        try:
+            from helpers.autofix import attempt_autofix
+            pr_url = attempt_autofix(result)
+            if pr_url:
+                await ctx.send(channel, f"✅ Auto-fix PR created: {pr_url}")
+            else:
+                await ctx.send(channel, "⚠️ Auto-fix could not produce a fix.")
+        except Exception as exc:
+            await ctx.send(channel, f"⚠️ Auto-fix error: {exc}")
+
+    summary = result.summary()
+    if pr_url:
+        summary += f"\n\n🔧 **Auto-fix PR:** {pr_url}"
+    await ctx.send(channel, summary)
 
     # Cross-post failures to reliability channel
     if not result.success and config.SMOKETEST_CHANNEL_ID:
@@ -50,7 +67,7 @@ async def handle_smoketest(
             import discord
             reliability_ch = ctx.bot.get_channel(config.SMOKETEST_CHANNEL_ID)
             if reliability_ch:
-                await reliability_ch.send(result.summary())
+                await reliability_ch.send(summary)
         except Exception:
             pass
 
@@ -85,8 +102,26 @@ async def _run_standalone(channel_id: Optional[int] = None) -> None:
         owner_id=_cfg.DISCORD_ALLOWED_USER_ID or None,
     )
 
+    # Attempt auto-fix if smoke test failed
+    pr_url = None
+    if not result.success and _cfg.AUTO_FIX_ON_FAILURE:
+        print("\n🔧 Smoke test failed — attempting auto-fix...")
+        try:
+            from helpers.autofix import attempt_autofix
+            pr_url = attempt_autofix(result)
+            if pr_url:
+                print(f"✅ Auto-fix PR created: {pr_url}")
+            else:
+                print("⚠️ Auto-fix could not produce a fix.")
+        except Exception as exc:
+            print(f"⚠️ Auto-fix error: {exc}")
+
+    summary = result.summary()
+    if pr_url:
+        summary += f"\n\n🔧 **Auto-fix PR:** {pr_url}"
+
     print("\n" + "=" * 60)
-    print(result.summary().replace("**", "").replace("`", ""))
+    print(summary.replace("**", "").replace("`", ""))
     print("=" * 60)
 
     # Post to Discord channel if requested
@@ -100,7 +135,7 @@ async def _run_standalone(channel_id: Optional[int] = None) -> None:
         async def on_ready():
             ch = client.get_channel(channel_id)
             if ch:
-                await ch.send(result.summary())
+                await ch.send(summary)
             await client.close()
 
         await client.start(_cfg.DISCORD_BOT_TOKEN)

--- a/config.py
+++ b/config.py
@@ -94,6 +94,7 @@ MAX_BUILD_ATTEMPTS: int = int(os.getenv("MAX_BUILD_ATTEMPTS", "8"))
 MAX_FIX_BUDGET_USD: float = float(os.getenv("MAX_FIX_BUDGET_USD", "10"))
 SMOKETEST_CHANNEL_ID: int = int(os.getenv("SMOKETEST_CHANNEL_ID", "0"))
 MAX_TOTAL_INVOCATIONS: int = int(os.getenv("MAX_TOTAL_INVOCATIONS", "20"))
+AUTO_FIX_ON_FAILURE: bool = os.getenv("AUTO_FIX_ON_FAILURE", "1") == "1"
 
 
 def validate() -> list[str]:

--- a/helpers/autofix.py
+++ b/helpers/autofix.py
@@ -1,0 +1,189 @@
+"""
+helpers/autofix.py — Auto-fix PR on smoke test failure.
+
+When a smoke test fails, this module:
+1. Analyzes the failure (which stage broke, what error)
+2. Creates a fix branch: autofix/smoke-YYYY-MM-DD
+3. Runs Claude CLI with a targeted prompt based on the failure
+4. If Claude makes changes, commits them and creates a PR via `gh pr create`
+5. Returns the PR URL or None
+"""
+
+import logging
+import subprocess
+from datetime import date
+from typing import Optional
+
+import config
+from helpers.smoketest_runner import SmokeTestResult
+
+log = logging.getLogger(__name__)
+
+BOT_REPO = "/Users/jaredtanpersonal/bots/discord-claude-bridge"
+GITHUB_REMOTE = "jardysuntan/discord-claude-app-builder"
+
+
+def _first_failure(result: SmokeTestResult) -> tuple[str, str]:
+    """Return (stage_name, detail) for the first failed stage."""
+    for stage in result.stages:
+        if not stage.passed:
+            return stage.name, stage.detail
+    return "unknown", ""
+
+
+def _build_prompt(stage_name: str, detail: str) -> str:
+    """Build a targeted Claude prompt based on the failure stage and error."""
+    return (
+        f"The nightly smoke test failed at stage: {stage_name}\n"
+        f"Error details:\n{detail}\n\n"
+        "The smoke test runs a full buildapp cycle: create KMP workspace, "
+        "generate code with Claude, build Android, build Web, take screenshot.\n\n"
+        "Investigate the bot's own codebase to find the root cause of this "
+        "failure and fix it. The failure is in the bot infrastructure, not in "
+        "generated app code. Look at helpers/smoketest_runner.py, agent_loop.py, "
+        "platforms/, and related modules.\n\n"
+        "Only change what is necessary to fix the issue. Do not refactor or "
+        "add unrelated improvements."
+    )
+
+
+def attempt_autofix(result: SmokeTestResult) -> Optional[str]:
+    """Analyze a smoke test failure and attempt an automated fix.
+
+    Returns the PR URL if a fix was created, or None.
+    """
+    if result.success:
+        return None
+
+    stage_name, detail = _first_failure(result)
+    if stage_name == "unknown":
+        log.warning("autofix: no failed stage found in result")
+        return None
+
+    branch = f"autofix/smoke-{date.today().isoformat()}"
+    log.info("autofix: failure at '%s', creating branch %s", stage_name, branch)
+
+    try:
+        # Ensure we're on a clean main branch before branching
+        subprocess.run(
+            ["git", "checkout", "main"],
+            cwd=BOT_REPO, check=True, capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "pull", "--ff-only"],
+            cwd=BOT_REPO, check=True, capture_output=True, text=True,
+        )
+
+        # Delete local branch if it already exists (re-run on same day)
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=BOT_REPO, capture_output=True, text=True,
+        )
+
+        subprocess.run(
+            ["git", "checkout", "-b", branch],
+            cwd=BOT_REPO, check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.error("autofix: git branch setup failed: %s", exc.stderr)
+        return None
+
+    # Run Claude CLI to attempt the fix
+    prompt = _build_prompt(stage_name, detail)
+    log.info("autofix: running Claude CLI on %s", BOT_REPO)
+    try:
+        subprocess.run(
+            [
+                config.CLAUDE_BIN,
+                "--print",
+                "--dangerously-skip-permissions",
+                "-p", prompt,
+            ],
+            cwd=BOT_REPO,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired:
+        log.error("autofix: Claude CLI timed out")
+        _cleanup_branch(branch)
+        return None
+    except subprocess.CalledProcessError as exc:
+        log.error("autofix: Claude CLI failed: %s", exc.stderr[:500])
+        _cleanup_branch(branch)
+        return None
+
+    # Check if Claude made any changes
+    diff = subprocess.run(
+        ["git", "diff", "--stat"],
+        cwd=BOT_REPO, capture_output=True, text=True,
+    )
+    if not diff.stdout.strip():
+        log.info("autofix: Claude made no changes")
+        _cleanup_branch(branch)
+        return None
+
+    # Commit and push
+    try:
+        subprocess.run(
+            ["git", "add", "-A"],
+            cwd=BOT_REPO, check=True, capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m",
+             f"autofix: smoke test failure at '{stage_name}'\n\n"
+             f"Automated fix for nightly smoke test failure.\n"
+             f"Stage: {stage_name}\n"
+             f"Error: {detail[:200]}"],
+            cwd=BOT_REPO, check=True, capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "push", "-u", "origin", branch],
+            cwd=BOT_REPO, check=True, capture_output=True, text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        log.error("autofix: commit/push failed: %s", exc.stderr)
+        _cleanup_branch(branch)
+        return None
+
+    # Create PR via gh CLI
+    try:
+        pr_result = subprocess.run(
+            [
+                "gh", "pr", "create",
+                "--repo", GITHUB_REMOTE,
+                "--title", f"autofix: smoke test failure at '{stage_name}'",
+                "--body",
+                f"## Automated Fix\n\n"
+                f"The nightly smoke test failed at **{stage_name}**.\n\n"
+                f"```\n{detail[:500]}\n```\n\n"
+                f"This PR was created automatically by the autofix system.\n\n"
+                f"🤖 Generated by autofix",
+                "--head", branch,
+                "--base", "main",
+            ],
+            cwd=BOT_REPO,
+            check=True, capture_output=True, text=True,
+        )
+        pr_url = pr_result.stdout.strip()
+        log.info("autofix: PR created — %s", pr_url)
+        return pr_url
+    except subprocess.CalledProcessError as exc:
+        log.error("autofix: gh pr create failed: %s", exc.stderr)
+        return None
+
+
+def _cleanup_branch(branch: str) -> None:
+    """Switch back to main and delete the fix branch."""
+    try:
+        subprocess.run(
+            ["git", "checkout", "main"],
+            cwd=BOT_REPO, capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=BOT_REPO, capture_output=True, text=True,
+        )
+    except Exception:
+        pass


### PR DESCRIPTION
Closes #17

When a nightly smoke test fails:
1. Analyzes which stage broke and the error details
2. Creates an `autofix/smoke-YYYY-MM-DD` branch
3. Runs Claude CLI with a targeted fix prompt
4. If Claude makes changes → commits, pushes, opens a PR automatically
5. PR link included in the failure report posted to #smoke-tests

New files:
- `helpers/autofix.py` — core autofix logic
- `config.AUTO_FIX_ON_FAILURE` flag (default True)

Integrated into both slash command and standalone cron runner.