### PR TITLE
feat: Trusted bot support for Jablue/Aibert orchestration

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -95,7 +95,9 @@ async def on_member_join(member: discord.Member):
 
 @client.event
 async def on_message(message: discord.Message):
-    if message.author.bot:
+    # Allow trusted bots (e.g., Jablue/Aibert orchestration)
+    TRUSTED_BOTS = {1484031871586402364}  # Jablue bot user ID
+    if message.author.bot and message.author.id not in TRUSTED_BOTS:
         return
 
     # ── Play Store JSON key upload ────────────────────────────────────


### PR DESCRIPTION
## What
Adds a `TRUSTED_BOTS` allowlist in `on_message` so specified bots can interact with ClaudeAppBot. Currently allows Jablue (Aibert's Discord bot) to send build commands.

## Why
Enables Jablue to orchestrate app building — plan features, write specs, then pipe `/buildapp` and `@workspace` commands to ClaudeAppBot. This is the foundation for bot-as-a-service architecture.

## Changes
- `bot.py`: Added `TRUSTED_BOTS` set with Jablue's bot user ID
- Bot messages from trusted bots are processed instead of ignored
- All other bot messages still filtered as before

## Future
- Option 2: Full HTTP API layer (`POST /api/buildapp`, etc.) for programmatic access
- This change is forward-compatible — trusted bot concept stays regardless of API transport

## Testing
- Jablue sends `/buildapp` via Discord DM or channel → ClaudeAppBot processes it
- Non-trusted bots still ignored ✅