### PR TITLE
feat(planapp): refine-plan modal replaces edit-plan round-trip

### DIFF
--- a/commands/planapp.py
+++ b/commands/planapp.py
@@ -14,6 +14,58 @@ from agent_protocol import AgentRunner
 from workspace_spec import build_workspace_spec, save_workspace_spec
 
 
+REFINE_PROMPT = """You are an expert mobile app architect. A user has reviewed an existing
+app plan and wants changes. Update the plan according to their instructions and return
+the COMPLETE revised plan as JSON.
+
+Original description: {description}
+
+Current plan (JSON):
+{current_plan}
+
+User's requested changes:
+{changes}
+
+Output the COMPLETE updated plan as a single JSON object (no markdown fences, just raw JSON)
+using EXACTLY this structure:
+{{
+  "app_name": "SuggestedAppName",
+  "summary": "One-sentence summary of what the app does",
+  "screens": [
+    {{
+      "name": "Screen Name",
+      "description": "What this screen shows and does",
+      "key_components": ["Component1", "Component2"]
+    }}
+  ],
+  "navigation": {{
+    "type": "bottom_tabs | drawer | stack",
+    "flow": "Brief description of how users move between screens"
+  }},
+  "data_model": [
+    {{
+      "entity": "EntityName",
+      "fields": ["field1: Type", "field2: Type"],
+      "description": "What this entity represents"
+    }}
+  ],
+  "features": [
+    "Feature 1 description",
+    "Feature 2 description"
+  ],
+  "tech_decisions": [
+    "Decision 1",
+    "Decision 2"
+  ]
+}}
+
+Rules:
+- Apply the user's changes precisely
+- Preserve everything else from the current plan
+- Output ONLY the JSON object, no other text
+"""
+
+
 PLAN_PROMPT = """You are an expert mobile app architect. Given the app description below,
 generate a structured plan for a Kotlin Multiplatform (Compose Multiplatform) app.
 
@@ -164,6 +216,34 @@ async def generate_plan(
             )
             save_workspace_spec(workspace_path, spec)
     return plan
+
+
+async def refine_plan(
+    current_plan: dict,
+    changes: str,
+    claude: AgentRunner,
+    workspace_key: str = "_planapp",
+    workspace_path: str = "/tmp",
+) -> Optional[dict]:
+    """Refine an existing plan based on user-requested changes. Returns updated plan or None."""
+    description = current_plan.get("_original_description", "")
+    # Strip the _original_description from the JSON we show to Claude
+    plan_for_prompt = {k: v for k, v in current_plan.items() if not k.startswith("_")}
+    prompt = REFINE_PROMPT.format(
+        description=description,
+        current_plan=json.dumps(plan_for_prompt, indent=2),
+        changes=changes,
+    )
+    result = await claude.run(prompt, workspace_key, workspace_path)
+
+    if result.exit_code != 0:
+        return None
+
+    updated = parse_plan_json(result.stdout)
+    if updated:
+        # Preserve the original description
+        updated["_original_description"] = description
+    return updated
 
 
 def plan_to_buildapp_prompt(plan: dict) -> str:

--- a/views/planapp_views.py
+++ b/views/planapp_views.py
@@ -45,44 +45,6 @@ def get_plan(user_id: int) -> dict | None:
     return plans.get(str(user_id))
 
 
-def _plan_to_editable_text(plan: dict) -> str:
-    """Convert a plan dict into human-readable text for editing in the modal."""
-    lines = []
-    if plan.get("app_name"):
-        lines.append(f"App: {plan['app_name']}")
-    if plan.get("summary"):
-        lines.append(plan["summary"])
-    lines.append("")
-
-    for s in plan.get("screens", []):
-        comps = ", ".join(s.get("key_components", []))
-        lines.append(f"Screen: {s['name']} — {s['description']}")
-        if comps:
-            lines.append(f"  Components: {comps}")
-
-    nav = plan.get("navigation", {})
-    if nav:
-        lines.append(f"\nNav: {nav.get('type', 'stack')} — {nav.get('flow', '')}")
-
-    for e in plan.get("data_model", []):
-        fields = ", ".join(e.get("fields", []))
-        lines.append(f"Data: {e['entity']} ({fields})")
-
-    features = plan.get("features", [])
-    if features:
-        lines.append("\nFeatures:")
-        for f in features:
-            lines.append(f"- {f}")
-
-    tech = plan.get("tech_decisions", [])
-    if tech:
-        lines.append("\nTech:")
-        for t in tech:
-            lines.append(f"- {t}")
-
-    return "\n".join(lines)[:4000]
-
-
 # ── Discord embed from plan ──────────────────────────────────────────────────
 
 def plan_embed(plan: dict) -> discord.Embed:
@@ -278,11 +240,90 @@ class _PlanActionView(discord.ui.View):
             self.ctx.registry.set_default(self.user_id, slug)
             await self.ctx.send(self.channel, f"📂 Switched to **{slug}**")
 
-    @discord.ui.button(label="Edit plan", style=discord.ButtonStyle.secondary, emoji="✏️")
+    @discord.ui.button(label="Refine plan", style=discord.ButtonStyle.secondary, emoji="✏️")
     async def replan(self, interaction: discord.Interaction, button: discord.ui.Button):
         if interaction.user.id != self.user_id:
             return await interaction.response.send_message("Not your command.", ephemeral=True)
-        prefill = _plan_to_editable_text(self.plan)
         await interaction.response.send_modal(
-            _PlanAppModal(self.ctx, self.channel, self.user_id, self.is_admin, prefill)
+            _RefinePlanModal(self.ctx, self.channel, self.user_id, self.is_admin, self.plan)
         )
+
+
+# ── Modal: refine an existing plan with small changes ───────────────────────
+
+class _RefinePlanModal(discord.ui.Modal, title="Refine your plan"):
+    changes = discord.ui.TextInput(
+        label="What would you like to change?",
+        style=discord.TextStyle.long,
+        placeholder=(
+            "e.g. 'add a Settings screen', 'remove the spin wheel game', "
+            "'use Ktor instead of the Supabase SDK', 'rename app to MyTrip'"
+        ),
+        required=True,
+        max_length=2000,
+    )
+
+    def __init__(self, ctx: BotContext, channel, user_id: int, is_admin: bool, plan: dict):
+        super().__init__()
+        self.ctx = ctx
+        self.channel = channel
+        self.user_id = user_id
+        self.is_admin = is_admin
+        self.plan = plan
+
+    async def on_submit(self, interaction: discord.Interaction):
+        changes = self.changes.value.strip()
+
+        await interaction.response.defer()
+        status_msg = await self.channel.send(
+            f"✏️ **Refining the plan...**\n_Applying: {changes[:200]}_",
+        )
+
+        stop_event = asyncio.Event()
+
+        async def progress_ticker():
+            while not stop_event.is_set():
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=15.0)
+                    return
+                except asyncio.TimeoutError:
+                    try:
+                        await status_msg.edit(
+                            content=f"⏳ **Still refining...**\n_Applying: {changes[:200]}_",
+                        )
+                    except Exception:
+                        pass
+
+        ticker_task = asyncio.create_task(progress_ticker())
+
+        try:
+            updated = await planapp.refine_plan(self.plan, changes, self.ctx.claude)
+        finally:
+            stop_event.set()
+            try:
+                await ticker_task
+            except Exception:
+                pass
+
+        if not updated:
+            try:
+                await status_msg.edit(
+                    content="❌ Could not refine the plan. Try describing the changes differently.",
+                )
+            except Exception:
+                await self.ctx.send(
+                    self.channel,
+                    "❌ Could not refine the plan. Try describing the changes differently.",
+                )
+            return
+
+        _save_plan(self.user_id, updated)
+
+        try:
+            await status_msg.edit(content="✅ **Plan updated!**")
+        except Exception:
+            pass
+
+        embed = plan_embed(updated)
+        view = _PlanActionView(self.ctx, self.channel, self.user_id, self.is_admin, updated)
+        await self.channel.send(embed=embed, view=view)


### PR DESCRIPTION
## Summary
- Replaces the \"Edit plan\" button (which tried to round-trip the full plan through a 4000-char modal) with a **\"Refine plan\"** button that asks \"What would you like to change?\"
- Adds \`refine_plan()\` + \`REFINE_PROMPT\` in \`commands/planapp.py\` — feeds current plan + change request to Claude, returns a full updated plan
- Removes the unused \`_plan_to_editable_text\` helper

## Why
The previous edit flow broke for any non-trivial plan because screens, data model, and features overflowed the single 4000-char TextInput and got silently truncated. Users couldn't meaningfully edit complex plans. Reported by jared.

## Test plan
- [ ] Run \`/planapp\` with a complex description → build a big plan
- [ ] Click **Refine plan** → verify the small modal appears with just one field
- [ ] Enter a change like \"add a Settings screen\" → verify updated plan appears with that screen added but everything else preserved
- [ ] Enter a change like \"rename app to MyTrip\" → verify \`app_name\` changes
- [ ] Enter a change like \"remove the spin wheel game\" → verify it's removed from features/screens
- [ ] Verify progress ticker edits the status message while refining

🤖 Generated with [Claude Code](https://claude.com/claude-code)