### PR TITLE
fix(buildapp): auto-switch default workspace inside handle_buildapp

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -250,6 +250,14 @@ async def handle_buildapp(
         await on_status(f"❌ Could not find workspace `{slug}`.", None)
         return None
 
+    # Auto-switch the user's default workspace to the new app immediately
+    # (before the long build loop), so subsequent commands target this workspace
+    # and the user knows exactly where we are. Works for any caller (planapp,
+    # buildapp view, API, etc.) since the set_default lives inside buildapp itself.
+    if owner_id is not None:
+        if registry.set_default(owner_id, slug):
+            await on_status(f"📂 Switched to **{slug}**", None)
+
     existing_spec = load_workspace_spec(ws_path)
     plan = existing_spec.get("plan") if existing_spec else None
     if not plan:

--- a/views/buildapp_views.py
+++ b/views/buildapp_views.py
@@ -98,14 +98,12 @@ class _BuildAppModal(discord.ui.Modal, title="Build a new app"):
             finally:
                 self.ctx.interview_pending.discard(pair)
 
-        slug = await buildapp.handle_buildapp(
+        # handle_buildapp auto-switches the default workspace inside the function
+        await buildapp.handle_buildapp(
             desc, self.ctx.registry, self.ctx.claude, ba_status,
             on_ask=ba_ask, is_admin=self.is_admin, owner_id=self.user_id,
             app_name=name,
         )
-        if slug:
-            self.ctx.registry.set_default(self.user_id, slug)
-            await self.ctx.send(self.channel, f"\U0001f4c2 Switched to **{slug}**")
 
 
 class _BuildAppView(discord.ui.View):

--- a/views/planapp_views.py
+++ b/views/planapp_views.py
@@ -227,7 +227,9 @@ class _PlanActionView(discord.ui.View):
         async def ba_status(msg, fpath=None):
             await self.ctx.send(self.channel, msg, file_path=fpath)
 
-        slug = await ba_handle(
+        # handle_buildapp auto-switches the default workspace right after
+        # create_kmp_project, so callers don't need a post-build set_default.
+        await ba_handle(
             enriched_desc,
             self.ctx.registry,
             self.ctx.claude,
@@ -236,9 +238,6 @@ class _PlanActionView(discord.ui.View):
             owner_id=self.user_id,
             app_name=app_name,
         )
-        if slug:
-            self.ctx.registry.set_default(self.user_id, slug)
-            await self.ctx.send(self.channel, f"📂 Switched to **{slug}**")
 
     @discord.ui.button(label="Refine plan", style=discord.ButtonStyle.secondary, emoji="✏️")
     async def replan(self, interaction: discord.Interaction, button: discord.ui.Button):


### PR DESCRIPTION
## Summary
- Moves the \`set_default\` call from the two caller views into \`handle_buildapp\` itself, right after \`create_kmp_project\` succeeds
- The switch now happens **immediately** after the workspace is created, not after the 3-5 minute build loop
- Removes the redundant \`set_default\` calls from \`views/planapp_views.py\` and \`views/buildapp_views.py\`

## Why
The previous flow ran \`set_default(user_id, slug)\` only after the whole build loop returned. Problems:
1. If the build hit an early return (e.g. Android loop failure), the switch might not fire depending on the slug return value
2. Users sending other commands during the 3-5 min build got routed to the OLD workspace
3. The \"📂 Switched to\" message appeared 5 minutes after the build actually started

Reported by jared after running \`/planapp\` → build for the \`wesobach\` app, then finding his next command still hit \`yangzihesobachmobile\`.

## Test plan
- [ ] Run \`/planapp\` in Discord, build a plan
- [ ] Click **Build this app**
- [ ] Verify \"📂 Switched to <slug>\" appears within seconds of the scaffold, not minutes
- [ ] While the build is still running, send \`@workspace <prompt>\` → verify it routes to the new workspace, not the old one
- [ ] After the build completes, send a free-form prompt → verify it routes to the new workspace
- [ ] Run \`/buildapp\` directly (not via planapp) → verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)