### PR TITLE
[auto-gap-fix] Teach Supabase Auth pattern for user account apps

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -178,6 +178,65 @@ Instructions for the backend integration:
 - Use "camelCase" property names in data classes — they match the DB column names exactly.
 """
 
+    # Detect auth-related apps and inject Supabase Auth pattern
+    desc_lower = description.lower()
+    auth_keywords = {"login", "signup", "sign up", "sign in", "sign-in", "sign-up",
+                     "auth", "user account", "password", "register", "registration",
+                     "log in", "log-in"}
+    if any(kw in desc_lower for kw in auth_keywords) and schema_sql and sb_anon_key:
+        supabase_url = f"https://{sb_project_ref}.supabase.co"
+        base += f"""
+
+## Authentication (Supabase Auth)
+
+This app needs user authentication. Implement the following pattern:
+
+### AuthState sealed class
+Create a sealed class in a dedicated `model/AuthState.kt` file:
+- `Unknown` — initial state before checking stored session
+- `Unauthenticated` — no valid token
+- `Authenticated(userId: String, email: String, accessToken: String, refreshToken: String)`
+
+### AuthRepository
+Create an `AuthRepository` class that:
+1. Signs up via POST to `{supabase_url}/auth/v1/signup` with JSON body `{{"email": ..., "password": ...}}`
+2. Signs in via POST to `{supabase_url}/auth/v1/token?grant_type=password` with JSON body `{{"email": ..., "password": ...}}`
+3. Signs out via POST to `{supabase_url}/auth/v1/logout` with `Authorization: Bearer <accessToken>`
+4. Persists access token, refresh token, user ID, and email to platform storage
+5. Recovers session on app launch from stored tokens (`loadPersistedSession()`)
+6. Refreshes expired tokens via POST to `{supabase_url}/auth/v1/token?grant_type=refresh_token`
+7. Exposes auth state so the UI can observe it
+8. Includes all required headers: `apikey: <anon_key>`, `Content-Type: application/json`
+
+For token persistence, use an `expect`/`actual` `PlatformPreferences` that wraps
+SharedPreferences on Android, NSUserDefaults on iOS, and localStorage on WASM.
+
+### AuthScreen
+Create an `AuthScreen` composable with:
+- Sign In / Sign Up tab toggle
+- Email and password text fields with basic validation
+- Error message display for failed attempts
+- Loading indicator during network calls
+- Do NOT use emoji in the UI — use Material Icons instead
+
+### Auth-Gated Routing in App.kt
+Gate the main content behind authentication:
+- `AuthState.Unknown` → show a centered `CircularProgressIndicator`
+- `AuthState.Unauthenticated` → show `AuthScreen`
+- `AuthState.Authenticated` → show main app content (tabs/screens)
+
+On launch, call `authRepository.loadPersistedSession()` to restore previous login.
+
+### Sign Out
+Add a sign-out option in the app's settings or profile area.
+Sign out must: call the server logout endpoint, clear persisted tokens, and
+reset the UI back to `AuthScreen`.
+
+### Authenticated API Calls
+Once signed in, include the user's access token in all Supabase REST/RPC calls:
+`Authorization: Bearer <accessToken>` (instead of the anon key).
+"""
+
     return base
 
 


### PR DESCRIPTION
## What the north star has

The weresobach north-star app has a complete Supabase Auth implementation: `AuthRepository` with email/password sign-up/sign-in, a three-state `AuthState` sealed class (Unknown/Unauthenticated/Authenticated), persistent session tokens via `PlatformPreferences`, token refresh, and auth-gated routing in `App.kt` that shows a loading spinner → AuthScreen → main content based on auth state.

- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/data/AuthRepository.kt`
- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/model/AuthState.kt`
- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/ui/screens/AuthScreen.kt`

## What the bot's generator currently produces

The bot-generated app (weresobachbottest) has no authentication at all. It uses a hardcoded join-code gate (`"TRIP2026"` / `"ORG2026"`) with no server validation, no session persistence, no sign-out, and no auth state management. The settings screen only has a theme toggle.

- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/ui/Screens.kt` (JoinCodeGate, lines 931-988)
- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/App.kt` (flat state machine, no auth)

## What this PR teaches the bot

Adds conditional auth pattern guidance to `build_feature_prompt()` in `buildapp.py`. When the app description contains auth-related keywords (login, signup, auth, etc.) and Supabase is configured, the bot now injects detailed instructions for generating: AuthState sealed class, AuthRepository with full Supabase Auth API integration, AuthScreen composable, auth-gated routing in App.kt, sign-out flow, and authenticated API calls.

- `commands/buildapp.py` (59 lines added to `build_feature_prompt()`)

## How to test

Run `/buildapp 'trip planner app with user login and signup'` in Discord. Verify the generated app includes:
1. An `AuthRepository.kt` with Supabase Auth API calls
2. An `AuthState` sealed class with Unknown/Unauthenticated/Authenticated states
3. An `AuthScreen` composable with sign-in/sign-up tabs
4. Auth-gated routing in `App.kt` (loading → auth → main content)
5. A sign-out option in settings

## Part of a batch

This is PR 1 of 3 opened this run. Sibling PRs: #65, #66.