### PR TITLE
[auto-gap-fix] Teach route state machine for multi-screen navigation

### DIFF
--- a/commands/planapp.py
+++ b/commands/planapp.py
@@ -40,7 +40,8 @@ using EXACTLY this structure:
   ],
   "navigation": {{
     "type": "bottom_tabs | drawer | stack",
-    "flow": "Brief description of how users move between screens"
+    "flow": "Brief description of how users move between screens",
+    "routes": ["Route1", "Route2", "...one entry per distinct screen or flow step"]
   }},
   "data_model": [
     {{
@@ -84,7 +85,8 @@ Output a JSON object with EXACTLY this structure (no markdown fences, just raw J
   ],
   "navigation": {{
     "type": "bottom_tabs | drawer | stack",
-    "flow": "Brief description of how users move between screens"
+    "flow": "Brief description of how users move between screens",
+    "routes": ["Route1", "Route2", "...one entry per distinct screen or flow step"]
   }},
   "data_model": [
     {{
@@ -261,6 +263,15 @@ def plan_to_buildapp_prompt(plan: dict) -> str:
     nav = plan.get("navigation", {})
     if nav:
         parts.append(f"\nNavigation: {nav.get('type', 'stack')} — {nav.get('flow', '')}")
+        routes = nav.get("routes", [])
+        if len(routes) >= 2:
+            parts.append("\nRoute state machine implementation:")
+            parts.append("- Define an `enum class Route { " + ", ".join(routes) + " }` in App.kt")
+            parts.append("- Track `var currentRoute by remember { mutableStateOf(Route." + routes[0] + ") }` as top-level state")
+            parts.append("- Render screens with `when (currentRoute) { ... }` — one branch per Route")
+            parts.append("- Create navigation helper functions (e.g. `navigateTo(route: Route)`) that update currentRoute")
+            parts.append("- For list→detail flows, store the selected item ID alongside the route (e.g. `var selectedId by remember { ... }`)")
+            parts.append("- Separate each screen into its own composable function or file for clarity")
 
     entities = plan.get("data_model", [])
     if entities:

--- a/commands/planapp.py
+++ b/commands/planapp.py
@@ -267,11 +267,12 @@ def plan_to_buildapp_prompt(plan: dict) -> str:
         if len(routes) >= 2:
             parts.append("\nRoute state machine implementation:")
             parts.append("- Define an `enum class Route { " + ", ".join(routes) + " }` in App.kt")
-            parts.append("- Track `var currentRoute by remember { mutableStateOf(Route." + routes[0] + ") }` as top-level state")
+            parts.append("- Track `var currentRoute by rememberSaveable { mutableStateOf(Route." + routes[0] + ") }` as top-level state — use `rememberSaveable` (NOT `remember`) so route survives Android config changes and process death")
             parts.append("- Render screens with `when (currentRoute) { ... }` — one branch per Route")
             parts.append("- Create navigation helper functions (e.g. `navigateTo(route: Route)`) that update currentRoute")
-            parts.append("- For list→detail flows, store the selected item ID alongside the route (e.g. `var selectedId by remember { ... }`)")
+            parts.append("- For list→detail flows, store the selected item ID alongside the route (e.g. `var selectedId by rememberSaveable { ... }`)")
             parts.append("- Separate each screen into its own composable function or file for clarity")
+            parts.append("- If `navigation.type == \"bottom_tabs\"`, the Route enum is for CROSS-TAB flows (e.g. detail screens reachable from a tab) — NOT for the tabs themselves. Tabs are still tracked by their own `selectedTab` state.")
 
     entities = plan.get("data_model", [])
     if entities:


### PR DESCRIPTION
## What the north star has

The weresobach app uses a `Route` enum (`Auth, TripList, CreateTripChoice, CreateTripFromDoc, CreateTrip, JoinTrip, TripDetail`) with `currentRoute` state, `enterTrip(tripId)` / `exitToTripList()` navigation functions, and a `when (currentRoute)` block that renders the correct screen. Each screen is a separate composable file, and list→detail flows persist the selected trip ID alongside the route.

- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/App.kt` (Route enum at line 99, navigation functions at lines 200-220)
- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/ui/screens/TripListScreen.kt`

## What the bot's generator currently produces

The bot-generated app has no explicit route management. `App.kt` is a flat state machine with `selectedTab` as the only navigation state. All 1018 lines of screen composables live in a single monolithic `Screens.kt` file. There's no way to navigate between top-level flows (e.g., trip list → trip detail → create trip) — only tab switching within a single context.

- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/App.kt` (94 lines, tab-only navigation)
- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/ui/Screens.kt` (monolithic 1018 lines)

## What this PR teaches the bot

Enhances `planapp.py` in two places:
1. **PLAN_PROMPT**: Adds `routes` array to the navigation JSON, so the planner generates explicit route names for each distinct screen or flow step.
2. **plan_to_buildapp_prompt()**: When 2+ routes exist, emits concrete Compose implementation instructions — Route enum definition, mutableStateOf tracking, `when` branch rendering, navigation helpers, and guidance on separating screens into distinct files.

- `commands/planapp.py` (13 lines added across PLAN_PROMPT and plan_to_buildapp_prompt)

## How to test

1. Run `/planapp 'trip organizer with trip list, create trip, join trip, and trip detail views'` in Discord
2. Verify the plan JSON includes a `routes` array like `["TripList", "CreateTrip", "JoinTrip", "TripDetail"]`
3. Run `/buildapp` on the approved plan
4. Verify the generated `App.kt` includes a `Route` enum and `when (currentRoute)` branching

## Part of a batch

This is PR 2 of 3 opened this run. Sibling PRs: #64, #66.