### PR TITLE
buildapp prompt: handle email-confirm + preserve Content-Profile in auth section

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -219,6 +219,14 @@ Create an `AuthScreen` composable with:
 - Loading indicator during network calls
 - Do NOT use emoji in the UI — use Material Icons instead
 
+### Email Confirmation
+Supabase projects have email confirmation ON by default. After a successful
+sign-up, the user typically cannot sign in until they click the link in their
+email. Handle this explicitly: after `/auth/v1/signup`, check whether the
+response contains a `session` (auto-confirmed) or just a `user` (needs confirm).
+When it's the latter, show a clear "Check your email to confirm your account"
+message instead of attempting to route into the app.
+
 ### Auth-Gated Routing in App.kt
 Gate the main content behind authentication:
 - `AuthState.Unknown` → show a centered `CircularProgressIndicator`
@@ -234,7 +242,10 @@ reset the UI back to `AuthScreen`.
 
 ### Authenticated API Calls
 Once signed in, include the user's access token in all Supabase REST/RPC calls:
-`Authorization: Bearer <accessToken>` (instead of the anon key).
+`Authorization: Bearer <accessToken>` (instead of the anon key). Keep the
+`apikey: <anon_key>` header AND any `Content-Profile: <db_schema>` header from
+the base ConfigRepository pattern — the bearer token replaces the
+Authorization-side anon key only, not the schema or apikey headers.
 """
 
     return base


### PR DESCRIPTION
## Summary
Follow-up to #64. Two small additions to the Supabase Auth prompt block in `build_feature_prompt()`:

- **Email Confirmation subsection.** Default Supabase projects require email confirmation, so `/auth/v1/signup` returns a `user` but no `session`. Without guidance, a naive generated app routes into the main UI and silently 401s on every call. Now the prompt tells the bot to detect the user-only response and show a "check your email" message.
- **Content-Profile + apikey reminder in "Authenticated API Calls".** The base ConfigRepository pattern injects `Content-Profile: <db_schema>` for per-app schema isolation. The auth section previously told the bot to swap in `Authorization: Bearer <accessToken>` without reminding it to keep the schema header and apikey — generated apps would lose schema isolation once a user signed in.

Both surfaced during review of #64; merged that one as-is and pulled these into a follow-up.

## Test plan
- [ ] Run `/buildapp 'trip planner with user login'` — verify generated `AuthScreen` (or wherever the post-signup UX lives) handles the no-session response with a "check your email" path.
- [ ] In the same generated app, inspect any authenticated REST/RPC call site — verify `apikey: <anon_key>`, `Authorization: Bearer <accessToken>`, and (if a per-app schema is in use) `Content-Profile: <db_schema>` are all present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)