### PR TITLE
[auto-gap-fix] Teach Supabase Realtime WebSocket pattern

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -176,6 +176,34 @@ Instructions for the backend integration:
   3. Falls back to hardcoded demo data if the network call fails
 - The UI should load data from ConfigRepository on launch.
 - Use "camelCase" property names in data classes — they match the DB column names exactly.
+
+## Realtime Sync (Supabase Realtime via WebSocket)
+
+The app must live-update when data changes on the server. Implement a
+`SupabaseRealtime` class in commonMain that:
+
+1. Opens a WebSocket to `wss://<supabase_host>/realtime/v1/websocket?apikey=<anon_key>&vsn=1.0.0`
+   using Ktor's WebSockets plugin (add `io.ktor:ktor-client-websockets` dependency).
+2. Joins a single Phoenix channel `"realtime:db-changes"` by sending a `phx_join` message
+   whose `payload.config.postgres_changes` array subscribes to every app table
+   (event `"*"`, schema `"public"`).
+3. Sends a Phoenix heartbeat (`{{"topic":"phoenix","event":"heartbeat",...}}`) every 30 seconds.
+4. On receiving a `"postgres_changes"` event, calls an `onChangeDetected` callback.
+5. Auto-reconnects with a 5-second delay on failure; exposes a `status: StateFlow<String>`
+   for debug visibility ("idle", "connecting...", "live (N changes)", "error: ...").
+6. Provides `start(scope: CoroutineScope)` and `stop()` methods.
+
+Integrate into the app lifecycle:
+- `ConfigRepository` should own the `SupabaseRealtime` instance.
+  `startRealtime(scope)` creates it with `onChangeDetected = {{ refreshFromSupabase() }}`.
+- In `App.kt`, call `repository.startRealtime(scope)` inside a `LaunchedEffect`
+  and `repository.stopRealtime()` inside `DisposableEffect {{ onDispose {{ ... }} }}`.
+- When any admin/editor writes data (REST POST/PATCH/DELETE), immediately call
+  `repository.refreshFromSupabase()` for instant local feedback.
+  Other clients receive the update via the WebSocket broadcast automatically.
+
+Do NOT use any Supabase client library — raw Ktor WebSocket is the correct approach
+for KMP (no official Supabase Kotlin Realtime SDK exists for all targets).
 """
 
     return base


### PR DESCRIPTION
## What the north star has

The weresobach app implements live data sync via a `SupabaseRealtime` class that opens a raw Ktor WebSocket to Supabase Realtime, joins a single Phoenix channel (`realtime:db-changes`) with `postgres_changes` subscriptions on all 13 app tables, sends heartbeats every 30s, auto-reconnects on failure, and triggers a full config refresh via RPC on any detected change.

- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/data/SupabaseRealtime.kt`
- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/data/ConfigRepository.kt` (startRealtime/stopRealtime integration)

## What the bot's generator currently produces

The bot-generated app (weresobachbottest) has zero realtime capability. `ConfigRepository.kt` makes a single HTTP GET to `rpc/get_app_config` on launch and never updates again. No WebSocket, no channel subscriptions, no live sync.

- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/data/ConfigRepository.kt`

## What this PR teaches the bot

Adds a "Realtime Sync" section to the Supabase backend instructions in `build_feature_prompt()`. It teaches Claude to generate a `SupabaseRealtime` class using raw Ktor WebSockets (no SDK — correct for KMP), integrate it into ConfigRepository with start/stop lifecycle, and wire it into App.kt via LaunchedEffect/DisposableEffect. Also teaches the optimistic-refresh-after-write pattern for admin mutations.

- `commands/buildapp.py`

## How to test

Run `/buildapp 'trip planner app with shared itinerary'` in Discord and verify the generated output includes:
1. A `SupabaseRealtime.kt` (or equivalent class) with WebSocket connection to `wss://.../realtime/v1/websocket`
2. Phoenix channel join with `postgres_changes` subscriptions
3. `startRealtime()`/`stopRealtime()` calls in App.kt lifecycle
4. Ktor WebSocket dependency in build.gradle.kts

## Part of a batch

This is PR 1 of 3 opened this run. Sibling PRs: #69, #70.

https://claude.ai/code/session_012vDX7hxSqjMv1SHxb1hHRK