### PR TITLE
[auto-gap-fix] Teach loading, error, and empty state UI patterns

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -127,7 +127,50 @@ Requirements:
 - Verify the code compiles for Android target first
 - IMPORTANT: Do NOT use emoji characters (Unicode emoji) in the UI. They render as broken boxes on the Web (WASM) target. Use Material Icons from `androidx.compose.material.icons.Icons` instead.
 
-Write complete, working code. No TODOs or placeholders."""
+Write complete, working code. No TODOs or placeholders.
+
+## UI States: Loading, Error, and Empty
+
+Every screen that displays data from the backend MUST handle three states:
+
+### Loading state
+Show a centered `CircularProgressIndicator()` while data is being fetched for
+the first time. Use a `hasLoadedOnce` flag to distinguish initial load from
+subsequent refreshes (don't flash a spinner on every refresh):
+```
+val isLoading by repository.isLoading.collectAsState()
+var hasLoadedOnce by remember {{ mutableStateOf(false) }}
+LaunchedEffect(data) {{ if (data != null) hasLoadedOnce = true }}
+when {{
+    !hasLoadedOnce && isLoading -> CircularProgressIndicator()
+    items.isEmpty() -> EmptyState(...)
+    else -> ContentList(...)
+}}
+```
+
+### Empty state
+When a list has zero items, show a composable with a Material Icon, a heading,
+and a body message. If the user can take action, include a button:
+```
+@Composable fun EmptyState(icon: ImageVector, title: String, body: String,
+    actionLabel: String? = null, onAction: (() -> Unit)? = null)
+```
+Example: icon = `Icons.Outlined.EventNote`, title = "No events yet",
+body = "Events will appear here once they're created."
+
+### Error state
+When a network call fails, show an inline error message with `AnimatedVisibility`
+so it fades in/out. Include a retry action:
+```
+var error by remember {{ mutableStateOf<String?>(null) }}
+AnimatedVisibility(visible = error != null, enter = fadeIn(), exit = fadeOut()) {{
+    Text(error ?: "", color = MaterialTheme.colorScheme.error)
+}}
+```
+For form screens (login, join code entry), set `isError = true` on the
+`TextField` and show the error message in `supportingText`.
+
+Do NOT silently swallow errors or show nothing when data is missing."""
 
     # Resolve Supabase creds
     sb_project_ref = config.SUPABASE_PROJECT_REF


### PR DESCRIPTION
## What the north star has

The weresobach app implements three-state UI handling across its screens. TripListScreen uses a `hasLoadedOnce` guard with `CircularProgressIndicator` for initial load, a dedicated `EmptyTripList()` composable with heading + action buttons for empty state, and content rendering otherwise. AuthScreen and JoinCodeScreen use `AnimatedVisibility` for error message fade-in/out with `isError` on TextFields. GolfScreen shows a custom empty state when no rounds are scheduled.

- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/feature/trip_list/TripListScreen.kt` (three-state when block, EmptyTripList composable)
- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/feature/auth/AuthScreen.kt` (loading + error states)

## What the bot's generator currently produces

The bot-generated app has a global `LoadingScreen` with shimmer animation shown at app startup, and some empty state checks on 3 of 6 screens (Itinerary, Golf, Housing). But Games and Crew screens have no empty states. No screen has error handling for network failures — errors silently fall back to demo data. No animated error messages, no retry buttons, no per-screen loading indicators.

- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/ui/Screens.kt` (LoadingScreen + partial empty states, zero error states)

## What this PR teaches the bot

Adds a "UI States: Loading, Error, and Empty" section to the base feature prompt in `build_feature_prompt()`. This teaches Claude to generate: (1) a `hasLoadedOnce`-guarded loading spinner for initial data fetch, (2) a reusable `EmptyState` composable with Material Icon + heading + body + optional action button, and (3) animated inline error messages with retry affordance. Applies to all generated apps, not just Supabase-backed ones.

- `commands/buildapp.py`

## How to test

Run `/buildapp 'recipe collection app'` in Discord and verify the generated output includes:
1. A reusable `EmptyState` composable (or equivalent) with icon + text
2. `CircularProgressIndicator` on at least the main list screen, guarded by `hasLoadedOnce`
3. Error text with `AnimatedVisibility` or equivalent error display on form/data screens
4. No screen that silently shows a blank area when its data list is empty

## Part of a batch

This is PR 2 of 3 opened this run. Sibling PRs: #68, #70.

https://claude.ai/code/session_012vDX7hxSqjMv1SHxb1hHRK