### PR TITLE
[auto-gap-fix] Teach multi-tenant SQL schema with scoped RPCs

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -104,6 +104,28 @@ Rules:
 - ALL primary keys must be uuid. ALL foreign keys must also be uuid and reference
   the uuid primary key. Never mix types (e.g. text FK → uuid PK).
 - Keep it minimal — only tables the app clearly needs.
+
+Multi-instance / multi-tenant pattern:
+If the app manages user-created instances (e.g. trips, projects, workspaces,
+teams, classrooms), apply this pattern:
+- Create a root instance table (e.g. `trips`) with: id UUID PK, name TEXT,
+  "joinCode" TEXT UNIQUE, "createdAt" TIMESTAMPTZ, "createdBy" TEXT.
+  Add an index on "joinCode".
+- Create a membership table (e.g. `trip_members`) with: id UUID PK,
+  "<instanceId>" UUID NOT NULL REFERENCES <instances>(id) ON DELETE CASCADE,
+  "userId" UUID, role TEXT DEFAULT 'member', "joinedAt" TIMESTAMPTZ DEFAULT now().
+  Add indexes on both "<instanceId>" and "userId".
+- Add a "<instanceId>" UUID NOT NULL REFERENCES <instances>(id) ON DELETE CASCADE
+  column to EVERY data table, with an index on it.
+- Create a scoped RPC `get_<instance>_config(p_<instance>_id UUID)` that returns
+  all data for one instance via json_build_object, filtering every sub-query with
+  WHERE "<instanceId>" = p_<instance>_id. Use COALESCE(..., '[]'::json) for arrays.
+- Create a lookup RPC `get_<instance>_by_join_code(p_join_code TEXT)` that returns
+  the instance row matching the join code.
+- Create a user-trips RPC `get_my_<instances>(p_user_id UUID)` that returns all
+  instances the user belongs to via the membership table.
+- Keep the original `get_app_config()` as a backward-compat wrapper that calls
+  the scoped RPC with the first instance.
 """
 
 


### PR DESCRIPTION
## What the north star has

The weresobach app uses a full multi-tenant SQL schema: a `trips` root table (with joinCode, organizerCode, dates, location), a `trip_members` membership table (tripId + userId + role), and a `"tripId"` UUID FK column with index on every single data table (guests, events, venues, golf_rounds, etc. — 13 tables total). It has three scoped RPCs: `get_trip_config(p_trip_id)` returns all data filtered by trip, `get_trip_by_join_code(p_join_code)` looks up a trip by its invite code, and `get_my_trips(p_user_id, p_guest_id)` lists trips a user belongs to.

- `weresobach/supabase/migrations/001_multi_tenant.sql`
- `weresobach/supabase/schema.sql` (trips + trip_members table definitions)

## What the bot's generator currently produces

The bot-generated app has zero SQL files and no multi-instance awareness. The SCHEMA_PROMPT generates a flat schema with a single `get_app_config()` RPC that returns all rows from all tables with no scoping. There's no trips/projects root table, no membership table, no join-code lookup, and no way for a user to have their own instance of the app's data.

- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/data/ConfigRepository.kt` (single get_app_config call, no trip scoping)

## What this PR teaches the bot

Adds a "Multi-instance / multi-tenant pattern" section to SCHEMA_PROMPT that triggers when the app description implies user-created instances (trips, projects, workspaces, teams, classrooms). It teaches: root instance table with joinCode, membership table with role, instanceId FK on all data tables, scoped RPC for single-instance fetch, join-code lookup RPC, and user-instances listing RPC.

- `commands/buildapp.py`

## How to test

Run `/buildapp 'trip planner where friends create and join group trips'` in Discord and verify the generated SQL includes:
1. A `trips` (or equivalent) root table with `joinCode` column
2. A `trip_members` (or equivalent) membership table with `tripId` + `userId`
3. A `"tripId"` column on data tables (events, itinerary items, etc.)
4. A `get_trip_config(p_trip_id UUID)` scoped RPC
5. A `get_trip_by_join_code(p_join_code TEXT)` lookup RPC

## Part of a batch

This is PR 3 of 3 opened this run. Sibling PRs: #68, #69.

https://claude.ai/code/session_012vDX7hxSqjMv1SHxb1hHRK

---
_Generated by [Claude Code](https://claude.ai/code/session_012vDX7hxSqjMv1SHxb1hHRK)_