### PR TITLE
[auto-gap-fix] Teach SQL constraints and indexes in schema generation

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -104,6 +104,21 @@ Rules:
 - ALL primary keys must be uuid. ALL foreign keys must also be uuid and reference
   the uuid primary key. Never mix types (e.g. text FK → uuid PK).
 - Keep it minimal — only tables the app clearly needs.
+
+Data integrity — constraints and indexes:
+- CHECK constraints: any column with a fixed set of valid values (status, type,
+  category, role) MUST have a CHECK constraint. Example:
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'active', 'completed'))
+  Also use CHECK for numeric ranges: CHECK (score BETWEEN 1 AND 100).
+- UNIQUE constraints: when a combination of columns forms a natural key (e.g. one
+  vote per user per poll, one score per player per hole), add a UNIQUE constraint
+  on those columns. Example: UNIQUE ("userId", "pollId")
+- ON DELETE CASCADE: every foreign key that points to a parent row the child
+  cannot exist without should specify ON DELETE CASCADE. Example:
+  "projectId" UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE
+- Indexes: add CREATE INDEX IF NOT EXISTS on columns frequently used in WHERE or
+  JOIN clauses — especially foreign keys and lookup codes. Example:
+  CREATE INDEX IF NOT EXISTS tasks_project_id_idx ON tasks ("projectId");
 """
 
 


### PR DESCRIPTION
## What the north star has

The weresobach app uses rigorous SQL constraints throughout its schema: CHECK constraints for enum-like columns (e.g. `status IN ('going', 'maybe', 'not_going', 'pending')` on rsvps, `hole BETWEEN 1 AND 18` on golf_scores), UNIQUE constraints for natural keys (e.g. `UNIQUE ("roundId", "playerId", hole)` — one score per player per hole), ON DELETE CASCADE on all child-to-parent foreign keys, and indexes on every foreign key and lookup column.

- `weresobach/supabase/schema.sql` (CHECK on rsvps, decisions, updates, drink_counts, contests, golf_scores; UNIQUE on drink_counts, weight_entries, golf_tees, golf_scores)
- `weresobach/supabase/migrations/001_multi_tenant.sql` (ON DELETE CASCADE on all tripId FKs, CREATE INDEX IF NOT EXISTS on all tripId columns and joinCode)

## What the bot's generator currently produces

The SCHEMA_PROMPT generates tables with only uuid PKs, uuid FKs (no cascade behavior specified), and basic RLS. No CHECK constraints, no UNIQUE constraints, no ON DELETE CASCADE, and no indexes. This means generated apps accept invalid enum values, allow duplicate natural-key rows, leave orphaned child rows when parents are deleted, and perform full table scans on FK lookups.

- `weresobachbottest/` has zero SQL files — all schema was generated at build time via the SCHEMA_PROMPT, which lacks these patterns

## What this PR teaches the bot

Adds a "Data integrity — constraints and indexes" section to SCHEMA_PROMPT that teaches four patterns: (1) CHECK constraints for enum/status/range columns, (2) UNIQUE constraints for multi-column natural keys, (3) ON DELETE CASCADE on parent-dependent FKs, (4) CREATE INDEX IF NOT EXISTS on FK and lookup columns. Each rule includes a concrete SQL example. Applies to all generated apps, not just multi-tenant ones.

- `commands/buildapp.py`

## How to test

Run `/buildapp 'task tracker with statuses and team assignments'` in Discord and verify the generated SQL includes:
1. A CHECK constraint on the task status column (e.g. `CHECK (status IN ('todo', 'in_progress', 'done'))`)
2. ON DELETE CASCADE on foreign keys linking tasks to projects or teams
3. CREATE INDEX on foreign key columns (e.g. `tasks_project_id_idx`)
4. A UNIQUE constraint if the schema has a natural key (e.g. one assignment per user per task)

## Part of a batch

This is PR 1 of 1 opened this run. Sibling PRs from prior run: #68, #69, #70. Next run: #72.

https://claude.ai/code/session_01FiYrUUBhsHi9TJtxjZPb63

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiYrUUBhsHi9TJtxjZPb63)_