### PR TITLE
[auto-gap-fix] Teach Snackbar feedback and confirmation dialog patterns

### DIFF
--- a/commands/buildapp.py
+++ b/commands/buildapp.py
@@ -127,7 +127,61 @@ Requirements:
 - Verify the code compiles for Android target first
 - IMPORTANT: Do NOT use emoji characters (Unicode emoji) in the UI. They render as broken boxes on the Web (WASM) target. Use Material Icons from `androidx.compose.material.icons.Icons` instead.
 
-Write complete, working code. No TODOs or placeholders."""
+Write complete, working code. No TODOs or placeholders.
+
+## User Feedback: Snackbar and Confirmation Dialogs
+
+Every app needs two feedback patterns — teach them from the start:
+
+### Snackbar for transient messages
+Set up a SnackbarHost at the App.kt root level (inside the root Box/Scaffold,
+aligned to BottomCenter). Create a `showSnackbar: (String) -> Unit` lambda
+using rememberCoroutineScope + SnackbarHostState and pass it down to screens
+that perform mutations. Use it for:
+- Success feedback after writes: "Saved", "Deleted", "Link copied"
+- Non-blocking errors: "Could not save — check your connection"
+
+Example wiring in App.kt:
+```kotlin
+val snackbarHostState = remember { SnackbarHostState() }
+val scope = rememberCoroutineScope()
+val showSnackbar: (String) -> Unit = { msg ->
+    scope.launch { snackbarHostState.showSnackbar(msg) }
+}
+// ... inside the root Box:
+SnackbarHost(
+    hostState = snackbarHostState,
+    modifier = Modifier.align(Alignment.BottomCenter)
+)
+```
+
+### AlertDialog for destructive actions
+Before any destructive action (delete, leave, sign out, reset), show an
+AlertDialog with a clear title, explanation of consequences, and
+confirm/dismiss buttons. Guard the confirm button with a loading indicator
+if the action is async. Pattern:
+```kotlin
+var showDeleteDialog by remember { mutableStateOf(false) }
+if (showDeleteDialog) {
+    AlertDialog(
+        onDismissRequest = { showDeleteDialog = false },
+        title = { Text("Delete item?") },
+        text = { Text("This cannot be undone.") },
+        confirmButton = {
+            TextButton(onClick = { /* perform delete, then showSnackbar("Deleted") */ }) {
+                Text("Delete")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+        }
+    )
+}
+```
+
+Do NOT skip feedback — every user-triggered mutation must produce visible
+confirmation via Snackbar, and every destructive action must require
+confirmation via AlertDialog."""
 
     # Resolve Supabase creds
     sb_project_ref = config.SUPABASE_PROJECT_REF


### PR DESCRIPTION
## What the north star has

The weresobach app uses a `SnackbarHost` at the App.kt root level with a `showSnackbar: (String) -> Unit` callback passed down to every screen that performs mutations. It fires on success ("Saved", "Link copied", "Deleted") and on non-blocking errors. It also uses `AlertDialog` for destructive action confirmation (delete account, leave trip, remove item) across 12+ files with 20+ instances — each with a clear title, consequence text, and confirm/dismiss buttons.

- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/App.kt` (SnackbarHost setup at lines 161–274, showSnackbar passed to screens)
- `weresobach/composeApp/src/commonMain/kotlin/com/weressobach/app/ui/screens/SettingsScreen.kt` (AlertDialog for account deletion with loading guard)

## What the bot's generator currently produces

The bot-generated app has zero SnackbarHost, zero showSnackbar calls, and zero AlertDialog instances. User-triggered mutations (if any) complete silently with no visible feedback. Destructive actions fire immediately with no confirmation step. The user has no way to know if their action succeeded or failed.

- `weresobachbottest/composeApp/src/commonMain/kotlin/com/jaredtan/wesobach/ui/Screens.kt` (no snackbar, no dialog — confirmed via grep)

## What this PR teaches the bot

Adds a "User Feedback: Snackbar and Confirmation Dialogs" section to `build_feature_prompt()` in `commands/buildapp.py`. It teaches two patterns with concrete Compose code examples: (1) SnackbarHost at the App.kt root with a showSnackbar lambda passed to screens, used after every mutation; (2) AlertDialog before destructive actions with title, consequence text, and confirm/dismiss buttons. Applies to all generated apps.

- `commands/buildapp.py`

## How to test

Run `/buildapp 'task list app where users can create and delete tasks'` in Discord and verify the generated output includes:
1. A `SnackbarHostState` + `SnackbarHost` in App.kt (or the root composable)
2. A `showSnackbar(...)` call after task creation (e.g. "Task added")
3. An `AlertDialog` confirmation before task deletion (e.g. "Delete task? This cannot be undone.")
4. No mutation that completes silently without snackbar feedback

## Part of a batch

This is PR 1 of 1 opened this run. Sibling PRs from prior runs: #68, #69, #70, #71.

https://claude.ai/code/session_01RJ1YbLVdtZMoNKh9BSbTKQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJ1YbLVdtZMoNKh9BSbTKQ)_